### PR TITLE
Fix panic when TransportInfo is nil

### DIFF
--- a/pkg/natsproxy/agent_test.go
+++ b/pkg/natsproxy/agent_test.go
@@ -200,7 +200,10 @@ func TestServeNewRequestExpectClose(t *testing.T) {
 	}
 
 	nc.Subscribe(inbox, pxyHandler)
-	req := &Request{TransportInfo: &TransportInfo{Sequence: 0}}
+	req := &Request{
+		Header:        make(map[string]*Values),
+		TransportInfo: &TransportInfo{Sequence: 0},
+	}
 	a.transports.init(inbox)
 	go a.serveNewRequest(inbox, req)
 
@@ -232,8 +235,14 @@ func TestServeNewRequestCancelFromProxy(t *testing.T) {
 	a := NewAgent(nc, agentID, nr, DefaultSubjectForAgentFunc(agentID.String()), time.Second)
 
 	reqs := []*Request{
-		{TransportInfo: &TransportInfo{Sequence: 0}},
-		{TransportInfo: &TransportInfo{Sequence: 1, Closing: true}},
+		{
+			Header:        make(map[string]*Values),
+			TransportInfo: &TransportInfo{Sequence: 0},
+		},
+		{
+			Header:        make(map[string]*Values),
+			TransportInfo: &TransportInfo{Sequence: 1, Closing: true},
+		},
 	}
 
 	for _, req := range reqs {

--- a/pkg/natsproxy/proxy.go
+++ b/pkg/natsproxy/proxy.go
@@ -246,7 +246,7 @@ func (t *Tunnel) recv(m *nats.Msg) {
 		t.done <- true
 	}
 	t.mux.Lock()
-	if response.TransportInfo.Sequence != t.sequence {
+	if response.TransportInfo == nil || response.TransportInfo.Sequence != t.sequence {
 		logrus.Errorf("Tunnel.recv unexpected sequence; expect %d, received %d", t.sequence, response.TransportInfo.Sequence)
 		t.mux.Unlock()
 		t.done <- true

--- a/pkg/natsproxy/proxy.go
+++ b/pkg/natsproxy/proxy.go
@@ -242,7 +242,7 @@ func (t *Tunnel) recv(m *nats.Msg) {
 	response := &Response{}
 	err := proto.Unmarshal(m.Data, response)
 	if err != nil {
-		logrus.Errorf("Tunnel.recv unmarshall err %s", err)
+		logrus.Errorf("Tunnel.recv unmarshal err %s", err)
 		t.done <- true
 	}
 	t.mux.Lock()


### PR DESCRIPTION
<!--
Thank you for helping to improve Upbound!

Please read through https://git.io/fj2m9 if this is your first time opening an
Upbound pull request. Find us in https://slack.crossplane.io/messages/upbound if
you need any help contributing.
-->

### Description of your changes

<!--
Briefly describe what this pull request does. Be sure to direct your reviewers'
attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, use the below
line to indicate which issue your PR fixes, for example "Fixes #500":
-->

Adds check for nil TransportInfo before checking sequence number.

Signed-off-by: hasheddan <georgedanielmangum@gmail.com>

> Also fixes up some tests that appear to have not been caught by CI. All of these fixes could potentially be implemented by updating our protobuf definitions, but I went for the simple fix for now. 

I have:

- [x] Read and followed Upbound's [contribution process](https://git.io/fj2m9).
- [x] Run `make reviewable` to ensure this PR is ready for review.
- [ ] Added `backport release-x.y` labels to auto-backport this PR, as appropriate.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change. Consider pasting snippets
with the commands or configurations you used to test, in case you or a reviewer
needs to repeat the test in future.
-->

This is somewhat difficult to replicate e2e, but this fix is in response to the following panic log, which clearly identifies the issue in question:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0xe12540]

goroutine 416 [running]:
github.com/upbound/nats-proxy/pkg/natsproxy.(*Tunnel).recv(0xc000670300, 0xc000556e40)
/home/upbound/go/pkg/mod/github.com/upbound/nats-proxy@v0.1.1/pkg/natsproxy/proxy.go:235 +0x160
github.com/nats-io/nats%2ego.(*Conn).waitForMsgs(0xc000184600, 0xc0005ae000)
/home/upbound/go/pkg/mod/github.com/nats-io/nats.go@v1.10.1-0.20210330225420-a0b1f60162f8/nats.go:2395 +0x342
created by github.com/nats-io/nats%2ego.(*Conn).subscribeLocked
/home/upbound/go/pkg/mod/github.com/nats-io/nats.go@v1.10.1-0.20210330225420-a0b1f60162f8/nats.go:3401 +0x4a5
```
